### PR TITLE
Updated license information

### DIFF
--- a/Rest2Mobile.podspec
+++ b/Rest2Mobile.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name     = 'Rest2Mobile'
-  s.version  = '1.1.1'
-  s.license  = 'Apache License 2.0'
+  s.version  = '1.1.2'
+  s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Use rest2mobile iOS SDK to develop iOS applications that communicate with REST/JSON APIs.'
   s.homepage = 'https://developer.magnet.com'
   #s.social_media_url = 'https://developer.magnet.com'
   s.authors  = { 'Magnet Systems, Inc.' => 'support@magnet.com' }
-  s.source   = { :git => 'https://github.com/magnetsystems/r2m-sdk-ios.git', :tag => "1.1.1", :submodules => true }
+  s.source   = { :git => 'https://github.com/magnetsystems/r2m-sdk-ios.git', :tag => "1.1.2", :submodules => true }
   s.requires_arc = true
 
   s.ios.deployment_target = '7.0'


### PR DESCRIPTION
Cocoadocs does not seem to like Apache License 2.0. Changing it to Apache License, Version 2.0
